### PR TITLE
Dispatch inbound WeChat image and video media

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,10 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import { getWeChatRuntime } from "./runtime.js";
 import { createWeChatReplyDispatcher } from "./reply-dispatcher.js";
+import {
+  buildInboundWeChatMediaContext,
+  resolveInboundWeChatMedia,
+} from "./inbound-media.js";
 import type { WechatMessageContext, ResolvedWeChatAccount } from "./types.js";
 
 // --- Message deduplication ---
@@ -55,9 +59,10 @@ export async function handleWeChatMessage(params: {
 
   log(`wechat[${accountId}]: received ${message.type} from ${message.sender.id}${isGroup ? ` in group ${message.group!.id}` : ""}`);
 
-  // Only handle text messages for now
-  if (message.type !== "text") {
-    log(`wechat[${accountId}]: ignoring non-text message type: ${message.type}`);
+  const inboundMedia = resolveInboundWeChatMedia(message);
+
+  if (message.type !== "text" && !inboundMedia) {
+    log(`wechat[${accountId}]: ignoring unsupported message type or media reference: ${message.type}`);
     return;
   }
 
@@ -81,7 +86,10 @@ export async function handleWeChatMessage(params: {
       },
     });
 
-    const preview = message.content.replace(/\s+/g, " ").slice(0, 160);
+    const messageText = inboundMedia
+      ? `[${inboundMedia.modality} attachment]`
+      : message.content;
+    const preview = messageText.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
       ? `WeChat[${accountId}] message in group ${message.group!.id}`
       : `WeChat[${accountId}] DM from ${message.sender.id}`;
@@ -95,7 +103,7 @@ export async function handleWeChatMessage(params: {
 
     // Build message body with speaker attribution
     const speaker = message.sender.name || message.sender.id;
-    const messageBody = `${speaker}: ${message.content}`;
+    const messageBody = `${speaker}: ${messageText}`;
 
     const envelopeFrom = isGroup
       ? `${message.group!.id}:${message.sender.id}`
@@ -111,8 +119,8 @@ export async function handleWeChatMessage(params: {
 
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: body,
-      RawBody: message.content,
-      CommandBody: message.content,
+      RawBody: messageText,
+      CommandBody: messageText,
       From: wechatFrom,
       To: wechatTo,
       SessionKey: route.sessionKey,
@@ -129,6 +137,7 @@ export async function handleWeChatMessage(params: {
       CommandAuthorized: true,
       OriginatingChannel: "wechat" as const,
       OriginatingTo: wechatTo,
+      ...buildInboundWeChatMediaContext(inboundMedia),
     });
 
     // Determine reply target: in groups reply to group, in DMs reply to sender

--- a/src/callback-server.ts
+++ b/src/callback-server.ts
@@ -111,7 +111,7 @@ function normalizePayload(payload: any): {
     content: data.content ?? "",
     newMsgId: data.newMsgId,
     timestamp: data.timestamp ?? payload.timestamp,
-    contentType: undefined,
+    contentType: data.contentType,
     raw: payload,
   };
 }
@@ -143,7 +143,7 @@ function isGroupMessage(messageType: string): boolean {
   return messageType.startsWith("8");
 }
 
-function convertToMessageContext(payload: any): WechatMessageContext | null {
+export function convertToMessageContext(payload: any): WechatMessageContext | null {
   const { messageType } = payload;
 
   // Offline notification
@@ -181,6 +181,7 @@ function convertToMessageContext(payload: any): WechatMessageContext | null {
       id: norm.wcId,
     },
     content: norm.content,
+    contentType: norm.contentType,
     timestamp: norm.timestamp || Date.now(),
     threadId: isGroup ? (norm.fromGroup || norm.fromUser) : norm.fromUser,
     raw: norm.raw,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -135,7 +135,7 @@ export const wechatPlugin: ChannelPlugin<ResolvedWeChatAccount> = {
   agentPrompt: {
     messageToolHints: () => [
       "- WeChat targeting: use `user:<wcId>` for direct messages, `group:<chatRoomId>` for groups.",
-      "- WeChat supports text, image, and file messages.",
+      "- WeChat supports text, image, video, and file messages.",
     ],
   },
 

--- a/src/inbound-media.ts
+++ b/src/inbound-media.ts
@@ -1,0 +1,54 @@
+import type { WechatMessageContext } from "./types.js";
+
+export type InboundWeChatMedia = {
+  url: string;
+  mimeType?: string;
+  modality: "image" | "video";
+};
+
+export type InboundWeChatMediaContext = {
+  SourceModality: "text" | "image" | "video";
+  MediaUrl?: string;
+  MediaUrls?: string[];
+  MediaType?: string;
+  MediaTypes?: string[];
+};
+
+export function resolveInboundWeChatMedia(
+  message: WechatMessageContext
+): InboundWeChatMedia | undefined {
+  if (message.type !== "image" && message.type !== "video") return undefined;
+
+  const url = message.content.trim();
+  if (!url) return undefined;
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return undefined;
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") return undefined;
+
+  const reportedType = message.contentType?.trim();
+  const mimeType = reportedType?.toLowerCase().startsWith(`${message.type}/`)
+    ? reportedType
+    : undefined;
+
+  return { url, mimeType, modality: message.type };
+}
+
+export function buildInboundWeChatMediaContext(
+  media: InboundWeChatMedia | undefined
+): InboundWeChatMediaContext {
+  if (!media) return { SourceModality: "text" };
+
+  return {
+    SourceModality: media.modality,
+    MediaUrl: media.url,
+    MediaUrls: [media.url],
+    MediaType: media.mimeType,
+    MediaTypes: media.mimeType ? [media.mimeType] : undefined,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export type WechatMessageContext = {
     id: string;
   };
   content: string;
+  contentType?: string;
   timestamp: number;
   threadId: string;
   group?: {

--- a/test/bot-media.test.ts
+++ b/test/bot-media.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildInboundWeChatMediaContext,
+  resolveInboundWeChatMedia,
+} from "../src/inbound-media.js";
+import { convertToMessageContext } from "../src/callback-server.js";
+import type { WechatMessageContext } from "../src/types.js";
+
+function createMessage(
+  type: WechatMessageContext["type"],
+  content: string,
+  contentType?: string
+): WechatMessageContext {
+  return {
+    id: "message-id",
+    type,
+    sender: { id: "sender-id", name: "Sender" },
+    recipient: { id: "recipient-id" },
+    content,
+    contentType,
+    timestamp: 1,
+    threadId: "sender-id",
+    raw: {},
+  };
+}
+
+describe("inbound WeChat media", () => {
+  it("preserves the image URL and matching MIME type", () => {
+    const media = resolveInboundWeChatMedia(
+      createMessage("image", "https://media.example/image.png", "image/png")
+    );
+
+    assert.deepEqual(media, {
+      url: "https://media.example/image.png",
+      mimeType: "image/png",
+      modality: "image",
+    });
+  });
+
+  it("accepts video URLs without trusting a mismatched MIME type", () => {
+    const media = resolveInboundWeChatMedia(
+      createMessage("video", "https://media.example/video.mp4", "image/png")
+    );
+
+    assert.deepEqual(media, {
+      url: "https://media.example/video.mp4",
+      mimeType: undefined,
+      modality: "video",
+    });
+  });
+
+  it("maps media into the OpenClaw inbound context", () => {
+    const media = resolveInboundWeChatMedia(
+      createMessage("image", "https://media.example/image.png", "image/png")
+    );
+
+    assert.deepEqual(buildInboundWeChatMediaContext(media), {
+      SourceModality: "image",
+      MediaUrl: "https://media.example/image.png",
+      MediaUrls: ["https://media.example/image.png"],
+      MediaType: "image/png",
+      MediaTypes: ["image/png"],
+    });
+    assert.deepEqual(buildInboundWeChatMediaContext(undefined), {
+      SourceModality: "text",
+    });
+  });
+
+  it("rejects non-media messages and non-HTTP media references", () => {
+    assert.equal(
+      resolveInboundWeChatMedia(createMessage("text", "https://media.example/image.png")),
+      undefined
+    );
+    assert.equal(
+      resolveInboundWeChatMedia(createMessage("image", "/tmp/image.png")),
+      undefined
+    );
+  });
+
+  it("propagates flat and nested callback MIME types", () => {
+    const flat = convertToMessageContext({
+      messageType: "60002",
+      wcId: "recipient-id",
+      fromUser: "sender-id",
+      content: "https://media.example/image.png",
+      contentType: "image/png",
+      newMsgId: "flat-id",
+    });
+    const nested = convertToMessageContext({
+      messageType: "60003",
+      wcId: "recipient-id",
+      data: {
+        fromUser: "sender-id",
+        content: "https://media.example/video.mp4",
+        contentType: "video/mp4",
+        newMsgId: "nested-id",
+      },
+    });
+
+    assert.equal(flat?.contentType, "image/png");
+    assert.equal(nested?.contentType, "video/mp4");
+  });
+});


### PR DESCRIPTION
Reason: The WeChat callback recognizes image and video messages, but the handler discards them before agent dispatch.

- Forward supported image and video URLs into the inbound agent context with matching MIME metadata.
- Preserve callback content types and continue rejecting unsupported or unsafe media references.
- Add focused coverage for callback normalization and inbound media context construction.

Checks:

- `./node_modules/.bin/tsx --test test/bot-media.test.ts`

AI disclosure: This pull request was prepared with Codex assistance for code changes and tests. A human maintainer must review and understand the patch before merge.
